### PR TITLE
Fix functions deprecated/shadowed by Base in exercise 21

### DIFF
--- a/02-exercises/21-writing_list_operations/problem.ml
+++ b/02-exercises/21-writing_list_operations/problem.ml
@@ -101,7 +101,7 @@ let%test _ =
    val mem : 'a list -> equal:('a -> 'a -> bool) -> 'a -> bool
 *)
 
-let () = assert (List.mem ~equal:Int.equal [1;2;3] 3 = true)
+let () = assert (List.mem ~equal:Int.equal [1;2;3] 3)
 
 (* List.sort returns a sorted list in increasing order according to the specified
    comparison function. The comparison function should return a negative number to
@@ -110,7 +110,7 @@ let () = assert (List.mem ~equal:Int.equal [1;2;3] 3 = true)
 
    val sort: cmp:('a -> 'a -> int) -> 'a list -> 'a list
 *)
-let () = assert (List.sort ~cmp:(fun x y -> x - y) [3;1;2] = [1;2;3])
+let () = assert ([%compare.equal: int list] (List.sort ~cmp:(fun x y -> x - y) [3;1;2]) [1;2;3])
 
 (*module My_list : sig
   val map : ('a -> 'b) -> 'a list -> 'b list
@@ -129,4 +129,4 @@ end = My_list*)
      Int.(=) 8 !acc
 
   let%test "Testing My_list.filter..." =
-    [%compare.equal: int list] [8 ; 2] (My_list.filter (fun x -> x mod 2 = 0) [1; 3; 7; 8; 9; 2])
+    [%compare.equal: int list] [8 ; 2] (My_list.filter (fun x -> x % 2 = 0) [1; 3; 7; 8; 9; 2])


### PR DESCRIPTION
Exercise 21 uses polymorphic compare and the Pervasives `mod`. This PR fixes those build errors.